### PR TITLE
20231228_fix to width 정적 값으로 할당

### DIFF
--- a/src/pages/ProjectPage/ProjectGridContainPC/index.tsx
+++ b/src/pages/ProjectPage/ProjectGridContainPC/index.tsx
@@ -241,11 +241,17 @@ const SubItemListTitle = styled.span`
   font-weight: 900;
   font-size: 16px;
   color: ${({ theme }) => theme.colors.orange};
+  @media screen and (max-width: 1200px) {
+    width: 90px;
+  }
 `;
 
 const SubItemListText = styled.span`
-  width: 100%;
+  width: 200px;
   font-size: 14px;
+  @media screen and (max-width: 1200px) {
+    width: 150px;
+  }
 `;
 
 const SubItemUrlText = styled.span`


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

-[] 기능 추가 - [] 기능 삭제 - [✔️] 버그 수정 - [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

- master

### 변경 사항

- 기존 SubItemListText css 컴포넌트에서 동적으로 width 값 할당 시 URL 부분이 다른 텍스트랑 정렬되지 않는 현상 수정
- 정적으로 width 값 할당 시 1200px 이하에서 SubItemListText css 컴포넌트 때문에 이미지가 밀리는 현상 수정

### 테스트 결과

- 1001 ~ 1199px 이하에서 올바르게 노출
- 1200px 이상에서 해당 컴포넌트의 url 부분은 좌측 정렬
